### PR TITLE
Count number of param at definition-site instead of use-site

### DIFF
--- a/input/src/main/scala/test/UseNamedParametersConfig.scala
+++ b/input/src/main/scala/test/UseNamedParametersConfig.scala
@@ -49,4 +49,6 @@ object UseNamedParametersConfig {
   VarArgs(a = "a", i = 1, 2, 3).varArgs("b", 4, 5, 6)
 
   new JavaClass(1, "s").method(2, "ss")
+  
+  List(1,2,3)
 }

--- a/output/src/main/scala/test/UseNamedParametersConfig.scala
+++ b/output/src/main/scala/test/UseNamedParametersConfig.scala
@@ -45,4 +45,6 @@ object UseNamedParametersConfig {
   VarArgs(a = "a", i = 1, 2, 3).varArgs(b = "b", i = 4, 5, 6)
 
   new JavaClass(1, "s").method(2, "ss")
+  
+  List(1,2,3)
 }


### PR DESCRIPTION
This means vararg params are now counted as just 1 parameter instead of however many the use-site is passing in.