### PR TITLE
Use '.atomic' where applicable

### DIFF
--- a/input/src/main/scala/test/UseNamedParameters.scala
+++ b/input/src/main/scala/test/UseNamedParameters.scala
@@ -16,4 +16,17 @@ object UseNamedParameters {
   new Three(1, 2, 3)
   new Four(1, 2, 3, 4)
   val makeFour: (Int, Int) => Four = new Four(1, _, _, 4)
+
+  object Suppresions {
+    // scalafix:off
+    Two(1, 2)
+    Three(1, 2, 3)
+    Four(1, 2, 3, 4)
+
+    new Two(1, 2)
+    new Three(1, 2, 3)
+    new Four(1, 2, 3, 4)
+    val makeFour: (Int, Int) => Four = new Four(1, _, _, 4)
+    // scalafix:on
+  }
 }

--- a/input/src/main/scala/test/UseNamedParametersMinParams.scala
+++ b/input/src/main/scala/test/UseNamedParametersMinParams.scala
@@ -52,4 +52,34 @@ object UseNamedParametersConfig {
 
   List(1, 2, 3).map { _.toLong }.map { case _ => 1 }
   Map.apply("a" -> 1, "b" -> 2)
+
+  object Suppressions {
+    // scalafix:off
+    Case(1, "s")
+    new Case(2, "s")
+    Case.apply(3, "z")
+    new Curry(1, "s")(5, 6.0, 7L)
+    
+    func(3, "s")
+    `cur)ried`(1, "s")(7, 8.0, 9L)
+    val partialApply = `cur)ried`(1, "s") _
+    partialApply(7, 8.0, 9L)
+    
+    overloaded(1, 2, 3)
+    overloaded(1, 2, "3")
+    
+    new Overload(1, 2L)
+    new Overload(1, 2).method(1, 2)
+    
+    TParam[Int](1, 2)
+    new TParam[Int](3, 4)
+    
+    TCurry[Long](1L, 2L)(3L, 4L)
+    new TCurry[Long](1L, 2L)(3L, 4L)
+    
+    VarArgs(a = "a", i = 1, 2, 3).varArgs("b", 4, 5, 6)
+    
+    List(1, 2, 3).map { _.toLong }.map { case _ => 1 }
+    // scalafix:on
+  }
 }

--- a/input/src/main/scala/test/UseNamedParametersSkipSingleAlphabet.scala
+++ b/input/src/main/scala/test/UseNamedParametersSkipSingleAlphabet.scala
@@ -40,4 +40,11 @@ object UseNamedParametersSkipSingleAlphabet {
   new JavaClass(1, "s").method(2, "ss")
 
   Map.apply("a" -> 1, "b" -> 2)
+
+  object Suppressions {
+    // scalafix:off
+    new Overload(1, 2L)
+    new Overload(1, 2).method(1, 2)
+    // scalafix:on
+  }
 }

--- a/output/src/main/scala-2.12/test/UseNamedParametersMinParams.scala
+++ b/output/src/main/scala-2.12/test/UseNamedParametersMinParams.scala
@@ -48,4 +48,34 @@ object UseNamedParametersConfig {
 
   List(xs = 1, 2, 3).map { _.toLong }.map { case _ => 1 }
   Map.apply("a" -> 1, "b" -> 2)
+
+  object Suppressions {
+    // scalafix:off
+    Case(1, "s")
+    new Case(2, "s")
+    Case.apply(3, "z")
+    new Curry(1, "s")(5, 6.0, 7L)
+    
+    func(3, "s")
+    `cur)ried`(1, "s")(7, 8.0, 9L)
+    val partialApply = `cur)ried`(1, "s") _
+    partialApply(7, 8.0, 9L)
+    
+    overloaded(1, 2, 3)
+    overloaded(1, 2, "3")
+    
+    new Overload(1, 2L)
+    new Overload(1, 2).method(1, 2)
+    
+    TParam[Int](1, 2)
+    new TParam[Int](3, 4)
+    
+    TCurry[Long](1L, 2L)(3L, 4L)
+    new TCurry[Long](1L, 2L)(3L, 4L)
+    
+    VarArgs(a = "a", i = 1, 2, 3).varArgs("b", 4, 5, 6)
+    
+    List(1, 2, 3).map { _.toLong }.map { case _ => 1 }
+    // scalafix:on
+  }
 }

--- a/output/src/main/scala-2.13/test/UseNamedParametersMinParams.scala
+++ b/output/src/main/scala-2.13/test/UseNamedParametersMinParams.scala
@@ -48,4 +48,34 @@ object UseNamedParametersConfig {
 
   List(1, 2, 3).map { _.toLong }.map { case _ => 1 }
   Map.apply("a" -> 1, "b" -> 2)
+
+  object Suppressions {
+    // scalafix:off
+    Case(1, "s")
+    new Case(2, "s")
+    Case.apply(3, "z")
+    new Curry(1, "s")(5, 6.0, 7L)
+    
+    func(3, "s")
+    `cur)ried`(1, "s")(7, 8.0, 9L)
+    val partialApply = `cur)ried`(1, "s") _
+    partialApply(7, 8.0, 9L)
+    
+    overloaded(1, 2, 3)
+    overloaded(1, 2, "3")
+    
+    new Overload(1, 2L)
+    new Overload(1, 2).method(1, 2)
+    
+    TParam[Int](1, 2)
+    new TParam[Int](3, 4)
+    
+    TCurry[Long](1L, 2L)(3L, 4L)
+    new TCurry[Long](1L, 2L)(3L, 4L)
+    
+    VarArgs(a = "a", i = 1, 2, 3).varArgs("b", 4, 5, 6)
+    
+    List(1, 2, 3).map { _.toLong }.map { case _ => 1 }
+    // scalafix:on
+  }
 }

--- a/output/src/main/scala/test/UseNamedParameters.scala
+++ b/output/src/main/scala/test/UseNamedParameters.scala
@@ -13,4 +13,17 @@ object UseNamedParameters {
   new Three(i = 1, j = 2, k = 3)
   new Four(i = 1, j = 2, k = 3, l = 4)
   val makeFour: (Int, Int) => Four = new Four(1, _, _, 4)
+
+  object Suppresions {
+    // scalafix:off
+    Two(1, 2)
+    Three(1, 2, 3)
+    Four(1, 2, 3, 4)
+
+    new Two(1, 2)
+    new Three(1, 2, 3)
+    new Four(1, 2, 3, 4)
+    val makeFour: (Int, Int) => Four = new Four(1, _, _, 4)
+    // scalafix:on
+  }
 }

--- a/output/src/main/scala/test/UseNamedParametersSkipSingleAlphabet.scala
+++ b/output/src/main/scala/test/UseNamedParametersSkipSingleAlphabet.scala
@@ -35,4 +35,11 @@ object UseNamedParametersSkipSingleAlphabet {
   new JavaClass(1, "s").method(2, "ss")
 
   Map.apply("a" -> 1, "b" -> 2)
+
+  object Suppressions {
+    // scalafix:off
+    new Overload(1, 2L)
+    new Overload(1, 2).method(1, 2)
+    // scalafix:on
+  }
 }


### PR DESCRIPTION
Hi! This PR makes the `UseNamedParameters` rule mark its patches as atomic using [.atomic](https://scalacenter.github.io/scalafix/docs/developers/patch.html#atomic) (the PR marks using named parameters for a whole call as atomic so you shouldn't see a case where the rule is applied to only part of call however a user chooses to use suppresions) which makes the rule respect supressions, and is also used by the scalafix api to group patches.

For the tests, I've duplicated occurrences where the rule changes something into a nested `Suppressions` object, though comments are of course welcome!

Thanks!